### PR TITLE
Add plain text version of Zen of Python

### DIFF
--- a/txt
+++ b/txt
@@ -1,0 +1,21 @@
+The Zen of Python, by Tim Peters
+
+Beautiful is better than ugly.
+Explicit is better than implicit.
+Simple is better than complex.
+Complex is better than complicated.
+Flat is better than nested.
+Sparse is better than dense.
+Readability counts.
+Special cases aren't special enough to break the rules.
+Although practicality beats purity.
+Errors should never pass silently.
+Unless explicitly silenced.
+In the face of ambiguity, refuse the temptation to guess.
+There should be one-- and preferably only one --obvious way to do it.
+Although that way may not be obvious at first unless you're Dutch.
+Now is better than never.
+Although never is often better than *right* now.
+If the implementation is hard to explain, it's a bad idea.
+If the implementation is easy to explain, it may be a good idea.
+Namespaces are one honking great idea -- let's do more of those!


### PR DESCRIPTION
## Which issues are addressed?

I was hoping that `curl http://pep20.org` would give me a plain text version, but it didn't.

I realized that this isn't possible currently because this is hosted on Netlify.

## What's implemented?

A single file with the plain text version of PEP 20.

## Why this implementation?

So I can `curl http://pep20.org/txt` (I hope this works at least...) to get the plain text of PEP 20.

## Any caveats?

I don't actually know whether this will work.

https://pep20.org/README.rst worked but https://pep20.org/.editorconfig did not. I'm hoping Netlify is just disallowing dotfiles from being accessed and not checking file extensions specifically (since `txt` doesn't even have an extension).

## Any additional notes?

If you feel this should be renamed to `zen.txt` or something else (shorter is preferable in my opinion) feel free to do so.

## Checklist

- [ ] Everything works.
- [ ] Test are present and pass.
- [ ] Documentation has been updated.

👆 I didn't do any of the above steps 😅